### PR TITLE
Added some more customization parameters I was missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A highly configurable navigation bar with emphasis for the selected item.
 ## Add dependency
 ```
 dependencies:
-  ff_navigation_bar: ^0.1.5
+  ff_navigation_bar: ^0.1.6
 ```
 
 ## Basic use
@@ -82,6 +82,14 @@ The navbar has a Theme class which can be used to define the majority of appeara
 * barHeight: The height for the bar (which is automatically included within a SafeArea widget)
 * itemWidth: The width to use for the selected item CircleAvater (default = 48.0)
 * showSelectedItemShadow: Indicates if the drop shadow below the selected item should be displayed (default = true)
+* barShadow: Optional BoxShadow effect of navigation bar
+* selectedItemBackgroundGradient: Optional LinearGradient of selected circle background (default uses selectedItemBackgroundColor)
+* unselectedItemIconGradient: Optional LinearGradient of unselected icon (default uses unselectedItemIconColor)
+* selectedItemBorderWidth: The thickness for the selected item's circle border (default = 4.0)
+* selectedItemIconSize: The size of the selected icon (default to theme)
+* unselectedItemIconSize: The size of the unselected icons (default to theme)
+* selectedItemTopOffset: The y offset of the selected icon's circle overhang (default = 10.0)
+
 
 ## FFNavigationBar Attributes
 * selectedIndex: The item number (zero indexed) which should be marked as selected
@@ -96,3 +104,4 @@ The navbar has a Theme class which can be used to define the majority of appeara
 * selectedBackgroundColor: A Color value which can override the theme's selectedItemBackgroundColor value for a specific navigation bar item (used to create different colors for each item)
 * selectedForegroundColor: A Color value which can override the theme's selectedItemIconColor value
 * selectedLabelColor: A Color value which can override the theme's selectedItemLabelColor value
+* onClick: Optional function call when clicking the already selected item.

--- a/example/android/local.properties
+++ b/example/android/local.properties
@@ -1,5 +1,5 @@
-sdk.dir=/Users/jwb/Library/Android/sdk
-flutter.sdk=/Users/jwb/Local/Workspaces/Unversioned/FlutterDevelopment
+sdk.dir=C:\\Users\\alanb\\AppData\\Local\\Android\\Sdk
+flutter.sdk=C:\\Android\\flutter
 flutter.buildMode=debug
 flutter.versionName=1.0.0
 flutter.versionCode=1

--- a/example/ios/Runner/GeneratedPluginRegistrant.h
+++ b/example/ios/Runner/GeneratedPluginRegistrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GeneratedPluginRegistrant_h
 #define GeneratedPluginRegistrant_h
 

--- a/example/ios/Runner/GeneratedPluginRegistrant.m
+++ b/example/ios/Runner/GeneratedPluginRegistrant.m
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #import "GeneratedPluginRegistrant.h"
 
 @implementation GeneratedPluginRegistrant

--- a/lib/ff_navigation_bar.dart
+++ b/lib/ff_navigation_bar.dart
@@ -51,6 +51,7 @@ class _FFNavigationBarState extends State<FFNavigationBar> {
         decoration: BoxDecoration(
           color: bgColor,
           boxShadow: [
+            theme.barShadow ??
             const BoxShadow(
               color: Colors.black12,
               blurRadius: 2,

--- a/lib/ff_navigation_bar.dart
+++ b/lib/ff_navigation_bar.dart
@@ -16,31 +16,27 @@ class FFNavigationBar extends StatefulWidget {
   final int selectedIndex;
 
   FFNavigationBar({
-    Key key,
+    Key? key,
     this.selectedIndex = 0,
-    @required this.onSelectTab,
-    @required this.items,
-    @required this.theme,
+    required this.onSelectTab,
+    required this.items,
+    required this.theme,
   }) {
-    assert(items != null);
     assert(items.length >= 2 && items.length <= 5);
-    assert(onSelectTab != null);
   }
 
   @override
-  _FFNavigationBarState createState() =>
-      _FFNavigationBarState(selectedIndex: selectedIndex);
+  _FFNavigationBarState createState() => _FFNavigationBarState(selectedIndex: selectedIndex);
 }
 
 class _FFNavigationBarState extends State<FFNavigationBar> {
-  int selectedIndex;
+  int? selectedIndex;
   _FFNavigationBarState({this.selectedIndex});
 
   @override
   Widget build(BuildContext context) {
     final FFNavigationBarTheme theme = widget.theme;
-    final bgColor =
-        theme.barBackgroundColor ?? Theme.of(context).bottomAppBarColor;
+    final bgColor = theme.barBackgroundColor;
 
     return MultiProvider(
       providers: [
@@ -52,10 +48,10 @@ class _FFNavigationBarState extends State<FFNavigationBar> {
           color: bgColor,
           boxShadow: [
             theme.barShadow ??
-            const BoxShadow(
-              color: Colors.black12,
-              blurRadius: 2,
-            ),
+                const BoxShadow(
+                  color: Colors.black12,
+                  blurRadius: 2,
+                ),
           ],
         ),
         child: SafeArea(
@@ -79,8 +75,7 @@ class _FFNavigationBarState extends State<FFNavigationBar> {
                   child: Container(
                     color: Colors.transparent,
                     child: SizedBox(
-                      width: MediaQuery.of(context).size.width /
-                          widget.items.length,
+                      width: MediaQuery.of(context).size.width / widget.items.length,
                       height: theme.barHeight,
                       child: item,
                     ),

--- a/lib/ff_navigation_bar_item.dart
+++ b/lib/ff_navigation_bar_item.dart
@@ -15,25 +15,25 @@ import 'dart:ui' as ui;
 // ignore: must_be_immutable
 class FFNavigationBarItem extends StatelessWidget {
   final String label;
-  final IconData iconData;
+  final IconData? iconData;
   final Duration animationDuration;
-  Color selectedBackgroundColor;
-  Color selectedForegroundColor;
-  Color selectedLabelColor;
+  Color? selectedBackgroundColor;
+  Color? selectedForegroundColor;
+  Color? selectedLabelColor;
 
-  int index;
-  int selectedIndex;
-  FFNavigationBarTheme theme;
-  bool showSelectedItemShadow;
+  int? index;
+  int? selectedIndex;
+  late FFNavigationBarTheme theme;
+  late bool showSelectedItemShadow;
   double itemWidth;
-  VoidCallback onClick;
+  VoidCallback? onClick;
 
   void setIndex(int index) {
     this.index = index;
   }
 
   Color _getDerivedBorderColor() {
-    return theme.selectedItemBorderColor ?? theme.barBackgroundColor;
+    return theme.selectedItemBorderColor;
   }
 
   Color _getBorderColor(bool isOn) {
@@ -47,8 +47,8 @@ class FFNavigationBarItem extends StatelessWidget {
   static const kDefaultAnimationDuration = Duration(milliseconds: 1500);
 
   FFNavigationBarItem({
-    Key key,
-    this.label,
+    Key? key,
+    required this.label,
     this.itemWidth = 60,
     this.selectedBackgroundColor,
     this.selectedForegroundColor,
@@ -65,27 +65,21 @@ class FFNavigationBarItem extends StatelessWidget {
         label,
         textAlign: TextAlign.center,
         style: TextStyle(
-          fontSize: isSelected
-              ? theme.selectedItemTextStyle.fontSize
-              : theme.unselectedItemTextStyle.fontSize,
-          fontWeight: isSelected
-              ? theme.selectedItemTextStyle.fontWeight
-              : theme.unselectedItemTextStyle.fontWeight,
-          color: isSelected
-              ? selectedLabelColor ?? theme.selectedItemLabelColor
-              : theme.unselectedItemLabelColor,
+          fontSize: isSelected ? theme.selectedItemTextStyle.fontSize : theme.unselectedItemTextStyle.fontSize,
+          fontWeight: isSelected ? theme.selectedItemTextStyle.fontWeight : theme.unselectedItemTextStyle.fontWeight,
+          color: isSelected ? selectedLabelColor ?? theme.selectedItemLabelColor : theme.unselectedItemLabelColor,
           letterSpacing: isSelected ? 1.1 : 1.0,
         ),
       ),
     );
   }
 
-  Widget _makeIconArea(double itemWidth, IconData iconData) {
+  Widget _makeIconArea(double itemWidth, IconData? iconData) {
     bool isSelected = _isItemSelected();
     double radius = itemWidth / 2;
     double innerBoxSize = itemWidth - 8;
     double innerRadius = (itemWidth - 8) / 2 - 4;
-    
+
     return AnimatedContainer(
       duration: animationDuration,
       width: itemWidth,
@@ -94,14 +88,10 @@ class FFNavigationBarItem extends StatelessWidget {
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         gradient: isSelected ? theme.selectedItemBackgroundGradient : null,
-        color: isSelected
-          ? selectedBackgroundColor ?? theme.selectedItemBackgroundColor
-          : theme.unselectedItemBackgroundColor,
+        color: isSelected ? selectedBackgroundColor ?? theme.selectedItemBackgroundColor : theme.unselectedItemBackgroundColor,
         border: Border.all(width: theme.selectedItemBorderWidth, color: _getBorderColor(isSelected)),
       ),
-      child: (isSelected && onClick != null) 
-        ? GestureDetector(onTap: onClick, child:_makeIcon(iconData))
-        : _makeIcon(iconData),
+      child: (isSelected && onClick != null) ? GestureDetector(onTap: onClick, child: _makeIcon(iconData)) : _makeIcon(iconData),
     );
     /*return CircleAvatar(
       radius: isSelected ? radius : radius * 0.7,
@@ -120,14 +110,13 @@ class FFNavigationBarItem extends StatelessWidget {
     );*/
   }
 
-  Widget _makeIcon(IconData iconData) {
+  Widget _makeIcon(IconData? iconData) {
     bool isSelected = _isItemSelected();
-    if(theme.unselectedItemIconGradient != null && !isSelected)
+    if (theme.unselectedItemIconGradient != null && !isSelected)
       return ShaderMask(
         blendMode: BlendMode.srcIn,
         shaderCallback: (Rect bounds) {
-          return ui.Gradient.linear((theme.unselectedItemIconGradient.begin as Alignment).alongSize(bounds.size),
-            (theme.unselectedItemIconGradient.end as Alignment).alongSize(bounds.size), theme.unselectedItemIconGradient.colors);
+          return ui.Gradient.linear((theme.unselectedItemIconGradient!.begin as Alignment).alongSize(bounds.size), (theme.unselectedItemIconGradient!.end as Alignment).alongSize(bounds.size), theme.unselectedItemIconGradient!.colors);
         },
         child: Icon(
           iconData,
@@ -135,15 +124,11 @@ class FFNavigationBarItem extends StatelessWidget {
         ),
       );
     else
-    return Icon(
-      iconData,
-      color: isSelected
-          ? selectedForegroundColor ?? theme.selectedItemIconColor
-          : theme.unselectedItemIconColor,
-      size: isSelected
-          ? theme.selectedItemIconSize
-          : theme.unselectedItemIconSize,
-    );
+      return Icon(
+        iconData,
+        color: isSelected ? selectedForegroundColor ?? theme.selectedItemIconColor : theme.unselectedItemIconColor,
+        size: isSelected ? theme.selectedItemIconSize : theme.unselectedItemIconSize,
+      );
   }
 
   Widget _makeShadow() {
@@ -159,10 +144,10 @@ class FFNavigationBarItem extends StatelessWidget {
         borderRadius: BorderRadius.all(Radius.elliptical(itemWidth / 2, 2)),
         boxShadow: [
           theme.barShadow ??
-          const BoxShadow(
-            color: Colors.black12,
-            blurRadius: 2,
-          ),
+              const BoxShadow(
+                color: Colors.black12,
+                blurRadius: 2,
+              ),
         ],
       ),
     );
@@ -175,10 +160,8 @@ class FFNavigationBarItem extends StatelessWidget {
     itemWidth = theme.itemWidth;
     selectedIndex = Provider.of<int>(context);
 
-    selectedBackgroundColor =
-        selectedBackgroundColor ?? theme.selectedItemBackgroundColor;
-    selectedForegroundColor =
-        selectedForegroundColor ?? theme.selectedItemIconColor;
+    selectedBackgroundColor = selectedBackgroundColor ?? theme.selectedItemBackgroundColor;
+    selectedForegroundColor = selectedForegroundColor ?? theme.selectedItemIconColor;
     selectedLabelColor = selectedLabelColor ?? theme.selectedItemLabelColor;
 
     bool isSelected = _isItemSelected();

--- a/lib/ff_navigation_bar_item.dart
+++ b/lib/ff_navigation_bar_item.dart
@@ -199,7 +199,7 @@ class FFNavigationBarItem extends StatelessWidget {
         width: itemWidth,
         height: itemHeight,
         child: Stack(
-          overflow: Overflow.visible,
+          clipBehavior: Clip.none,
           children: <Widget>[
             Positioned(
               top: topOffset,

--- a/lib/ff_navigation_bar_theme.dart
+++ b/lib/ff_navigation_bar_theme.dart
@@ -9,6 +9,13 @@ class FFNavigationBarTheme {
   final Color unselectedItemBackgroundColor;
   final Color unselectedItemIconColor;
   final Color unselectedItemLabelColor;
+  final LinearGradient selectedItemBackgroundGradient;
+  final LinearGradient unselectedItemIconGradient;
+  final BoxShadow barShadow;
+  final double selectedItemBorderWidth;
+  final double selectedItemIconSize;
+  final double unselectedItemIconSize;
+  final double selectedItemTopOffset;
 
   final TextStyle selectedItemTextStyle;
   final TextStyle unselectedItemTextStyle;
@@ -41,6 +48,13 @@ class FFNavigationBarTheme {
     this.unselectedItemBackgroundColor = Colors.transparent,
     this.unselectedItemIconColor = Colors.grey,
     this.unselectedItemLabelColor = Colors.grey,
+    this.selectedItemBackgroundGradient,
+    this.unselectedItemIconGradient,
+    this.barShadow,
+    this.selectedItemBorderWidth = 4,
+    this.selectedItemIconSize,
+    this.unselectedItemIconSize,
+    this.selectedItemTopOffset = 10.0,
     this.selectedItemTextStyle = kDefaultSelectedItemTextStyle,
     this.unselectedItemTextStyle = kDefaultUnselectedTextStyle,
     this.itemWidth = kDefaultItemWidth,

--- a/lib/ff_navigation_bar_theme.dart
+++ b/lib/ff_navigation_bar_theme.dart
@@ -9,12 +9,12 @@ class FFNavigationBarTheme {
   final Color unselectedItemBackgroundColor;
   final Color unselectedItemIconColor;
   final Color unselectedItemLabelColor;
-  final LinearGradient selectedItemBackgroundGradient;
-  final LinearGradient unselectedItemIconGradient;
-  final BoxShadow barShadow;
+  final LinearGradient? selectedItemBackgroundGradient;
+  final LinearGradient? unselectedItemIconGradient;
+  final BoxShadow? barShadow;
   final double selectedItemBorderWidth;
-  final double selectedItemIconSize;
-  final double unselectedItemIconSize;
+  final double? selectedItemIconSize;
+  final double? unselectedItemIconSize;
   final double selectedItemTopOffset;
 
   final TextStyle selectedItemTextStyle;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,13 +4,13 @@ version: 0.1.6
 homepage: https://github.com/55Builds/Flutter-FFNavigationBar
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
 
-  provider: ^4.0.2
+  provider: ^6.0.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  provider: ^6.0.2
+  provider:
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ff_navigation_bar
 description: Configurable bottom navigation bar with raised highlight and shadow
-version: 0.1.5
+version: 0.1.6
 homepage: https://github.com/55Builds/Flutter-FFNavigationBar
 
 environment:


### PR DESCRIPTION
First off, thanks for this NavBar alternative, I've been futzing with the Fancy Bottom Navigation addon for my app, but even after the mods I added to theirs, still wasn't quite right for the 5 button tabs I was going for.  Yours fit my needs better, but I had to hack in my mods to make it look right for me, and I assume others would like the same additions I did.  Here's the list of what I added:
* barShadow: Optional BoxShadow effect of navigation bar
* selectedItemBackgroundGradient: Optional LinearGradient of selected circle background (default uses selectedItemBackgroundColor)
* unselectedItemIconGradient: Optional LinearGradient of unselected icon (default uses unselectedItemIconColor)
* selectedItemBorderWidth: The thickness for the selected item's circle border (default = 4.0)
* selectedItemIconSize: The size of the selected icon (default to theme)
* unselectedItemIconSize: The size of the unselected icons (default to theme)
* selectedItemTopOffset: The y offset of the selected icon's circle overhang (default = 10.0)
Please feel free to make any changes to it, but did my best to keep it neat and easy for you, should you choose to accept this PR.. Without using any of these, it still looks like yours origionally.  The only part I still wasn't satisfied with is how the selected indicator comes in..  Would be nice finding some options for the entry animation when selecting items. I still might play with it more later, but I'm satisfied with it for now.  Thanks again..